### PR TITLE
Sapot Container v1.3 & Block OTA

### DIFF
--- a/System_Settings/BlockOTA/focal/ORIG/qml-plugins/system-update/PageComponent.qml
+++ b/System_Settings/BlockOTA/focal/ORIG/qml-plugins/system-update/PageComponent.qml
@@ -20,8 +20,8 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QMenuModel 1.0
 import QtQuick 2.4
+import QtQuick.Layouts 1.1
 import SystemSettings 1.0
 import Lomiri.Components 1.3
 import Lomiri.Components.ListItems 1.3 as ListItem
@@ -59,6 +59,7 @@ ItemPage {
                     dialog.accepted.connect(function() {
                         PopupUtils.close(dialog)
                         UpdateManager.reset()
+                        releaseUpgradeManager.check(/* force */ true)
                     });
                 }
             }
@@ -67,8 +68,8 @@ ItemPage {
 
 
     property bool batchMode: false
-    property bool havePower: (indicatorPower.deviceState === "charging") ||
-                             (indicatorPower.batteryLevel > 25)
+    property bool havePower: (Battery.state === Battery.Charging) ||
+                             (Battery.batteryLevel > 25)
     property bool online: NetworkingStatus.online
     property bool forceCheck: false
 
@@ -90,16 +91,12 @@ ItemPage {
                 UpdateManager.check(UpdateManager.CheckIfNecessary);
             }
         }
+
+        releaseUpgradeManager.check(force);
     }
 
-    QDBusActionGroup {
-        id: indicatorPower
-        busType: 1
-        busName: "org.ayatana.indicator.power"
-        objectPath: "/org/ayatana/indicator/power"
-        property var batteryLevel: action("battery-level").state || 0
-        property var deviceState: action("device-state").state
-        Component.onCompleted: start()
+    ReleaseUpgradeManager {
+        id: releaseUpgradeManager
     }
 
     Component {
@@ -221,7 +218,9 @@ ItemPage {
                         var s = UpdateManager.status;
                         if (!root.online) {
                             return I18nd.tr("Connect to the Internet to check for updates.");
-                        } else if (s === UpdateManager.StatusIdle && updatesCount === 0) {
+                        } else if (s === UpdateManager.StatusIdle &&
+                                   !updatesAvailableHeader.visible)
+                        {
                             return I18nd.tr("Software is up to date");
                         } else if (s === UpdateManager.StatusServerError ||
                                    s === UpdateManager.StatusNetworkError) {
@@ -235,7 +234,132 @@ ItemPage {
             SettingsItemTitle {
                 id: updatesAvailableHeader
                 text: I18nd.tr("Updates Available")
-                visible: imageUpdateCol.visible || clickUpdatesCol.visible
+                visible: imageUpdateCol.visible ||
+                         clickUpdatesCol.visible ||
+                         releaseUpgradeItem.visible
+            }
+
+            ColumnLayout {
+                id: releaseUpgradeItem
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                }
+                spacing: units.gu(2)
+
+                visible: releaseUpgradeManager.availableUpgrade &&
+                         updatesCount == 0 &&
+                         online
+
+                Icon {
+                    name: "distributor-logo"
+                    width: units.gu(10)
+                    height: width
+                    Layout.alignment: Qt.AlignHCenter
+
+                    LomiriShape {
+                        anchors {
+                            bottom: parent.bottom
+                            bottomMargin: units.gu(-1.5)
+                            right: parent.right
+                            rightMargin: units.gu(-1.5)
+                        }
+                        width: units.gu(4)
+                        height: width
+                        backgroundColor: theme.palette.normal.positive
+ 
+                        Icon {
+                            width: units.gu(3)
+                            height: width
+                            anchors {
+                                bottom: parent.bottom
+                                bottomMargin: units.gu(0.5)
+                                right: parent.right
+                                rightMargin: units.gu(0.5)
+                            }
+
+                            name: "save"
+                            color: theme.palette.normal.positiveText
+                        }
+                    }
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: units.gu(2)
+                    Layout.rightMargin: units.gu(2)
+
+                    Label {
+                        Layout.fillWidth: true
+                        text: releaseUpgradeManager.availableUpgrade
+                            // TRANSLATORS: %1 is OS name e.g. "Ubuntu Touch",
+                            // %2 is OS version e.g. "24.04-1.0 RC 3".
+                            ? I18nd.tr("%1 %2")
+                                .arg("Ubuntu Touch") // TODO: don't hardcode this.
+                                .arg(releaseUpgradeManager.availableUpgradeVersion)
+                            : ''
+                        wrapMode: Text.Wrap
+                        textSize: Label.Large
+                    }
+
+                    Button {
+                        id: releaseUpgradeBtn
+                        Layout.alignment: Qt.AlignHCenter
+                        text: I18nd.tr("Upgrade");
+                        color: theme.palette.normal.positive
+                        onClicked: {
+                            releaseUpgradeBtn.enabled = false;
+                            releaseUpgradeManager.startUpgrade().then(
+                            function () {
+                                // Normally this won't be visible, as the entry
+                                // should be replaced by normal update by then.
+                                // But if s-i-dbus stops in between, we want to
+                                // be able to re-trigger this.
+                                releaseUpgradeBtn.enabled = true;
+                            }).catch(function(error) {
+                                // TODO: there's not really an error handling...
+                                console.error(error);
+                                releaseUpgradeBtn.enabled = true;
+                            });
+                        }
+                    }
+                }
+
+                ActivityIndicator {
+                    Layout.alignment: Qt.AlignHCenter
+                    visible: releaseUpgradeManager.releaseHighlight === null
+                    running: visible
+                }
+
+                Label {
+                    id: releaseUpgradeHighlight
+
+                    Layout.fillWidth: true
+                    Layout.leftMargin: units.gu(2)
+                    Layout.rightMargin: units.gu(2)
+
+                    visible: releaseUpgradeManager.releaseHighlight &&
+                             releaseUpgradeManager.releaseHighlight.length > 0
+                    textSize: Label.Medium
+                    wrapMode: Text.WordWrap
+                    text: releaseUpgradeManager.releaseHighlight
+                    textFormat: Text.StyledText
+                    // A blue-ish color that adapts to theme. The same color as
+                    // an activity indicator/progress indicator.
+                    linkColor: theme.palette.normal.activity
+
+                    onLinkActivated: function (link) {
+                        Qt.openUrlExternally(link);
+                    }
+                }
+
+                // A wrapper item to put ThinDivider into a Layout, as it sets
+                // anchors implicitly.
+                Item {
+                    Layout.fillWidth: true
+                    
+                    ListItem.ThinDivider {}
+                }
             }
 
             Column {

--- a/WebContainer/SapotContainer/MOD/Chrome.qml
+++ b/WebContainer/SapotContainer/MOD/Chrome.qml
@@ -37,6 +37,7 @@ Sapot.ChromeBase {
     property color iconColor: theme.palette.normal.baseText
 
     property bool isPopupOverlay: false
+    property bool incognito: false
     property string searchUrl
 
     loading: webview && webview.loading && webview.loadProgress !== 100
@@ -198,7 +199,7 @@ Sapot.ChromeBase {
             Favicon {
                 anchors.centerIn: parent
                 source: chrome.webview ? chrome.webview.icon : null
-                shouldCache: chrome.isPopupOverlay && webapp.settings.incognitoOverlay ? false : true
+                shouldCache: chrome.isPopupOverlay && chrome.incognito ? false : true
             }
         }
 
@@ -230,11 +231,32 @@ Sapot.ChromeBase {
             width: visible ? height : 0
 
             anchors {
-                right: reloadButton.left
+                right: homeButton.left
                 verticalCenter: parent.verticalCenter
             }
 
             onTriggered: chrome.webview.toggleReaderMode()
+        }
+
+        ChromeButton {
+            id: homeButton
+            objectName: "homeButton"
+
+            iconName: "go-home"
+            iconSize: 0.6 * height
+            iconColor: chrome.iconColor
+
+            height: parent.height
+            visible: chrome.navigationButtonsVisible && !chrome.isPopupOverlay
+            width: visible ? height : 0
+
+            anchors {
+                right: reloadButton.left
+                verticalCenter: parent.verticalCenter
+            }
+
+            enabled: chrome.webview.url && chrome.webview.url !== ""
+            onTriggered: webapp.goHome()
         }
 
         ChromeButton {

--- a/WebContainer/SapotContainer/MOD/PopupWindowOverlay.qml
+++ b/WebContainer/SapotContainer/MOD/PopupWindowOverlay.qml
@@ -29,6 +29,7 @@ import QtQuick.Layouts 1.12
 FocusScope {
     id: popup
 
+    readonly property bool incognito: webContext === SharedWebContext.sharedIncognitoContext
     property var popupWindowController
     property var webContext
     property alias currentWebview: popupWebview
@@ -190,6 +191,7 @@ FocusScope {
         accountSwitcher: webapp.accountSwitcher
         availableHeight: popup.height
         wide: webapp.wide
+        incognito: popup.incognito
 
         anchors {
             top: parent.top

--- a/WebContainer/SapotContainer/MOD/WebApp.qml
+++ b/WebContainer/SapotContainer/MOD/WebApp.qml
@@ -390,6 +390,10 @@ Common.BrowserView {
         containerWebView.openOverlayForUrl(webapp.searchPageUrl, true)
     }
 
+    function goHome() {
+        actionsFactory.navigateToUrl(homeURL)
+    }
+
     onFindInPageModeChanged: {
         if (findInPageMode) {
             if (!findLoader.active) {

--- a/WebContainer/SapotContainer/MOD/WebViewImplOxide.qml
+++ b/WebContainer/SapotContainer/MOD/WebViewImplOxide.qml
@@ -72,7 +72,7 @@ WebappWebview {
     }
 */
     function openOverlayForUrl(overlayUrl, _incognito = false) {
-        let _context = webapp.settings.incognitoOverlay || _incognito ? SharedWebContext.sharedIncognitoContext : context
+        let _context = _incognito ? SharedWebContext.sharedIncognitoContext : context
         if (popupController) {
             popupController.createPopupViewForUrl(
                         overlayViewsParent,
@@ -141,7 +141,7 @@ WebappWebview {
         }
 
         function openLinkInOverlay(url, _isExternalLink = false) {
-            let _context = webapp.settings.incognitoOverlay || _isExternalLink ? SharedWebContext.sharedIncognitoContext : webview.context
+            let _context = webapp.settings.incognitoOverlay && _isExternalLink ? SharedWebContext.sharedIncognitoContext : webview.context
             popupController.createPopupViewForUrl(overlayViewsParent, url, true, _context)
         }  
     }
@@ -157,7 +157,7 @@ WebappWebview {
       
       if(request.userInitiated && shouldAllowNavigationTo(request.requestedUrl.toString()))
       {
-        let _context = webapp.settings.incognitoOverlay ? SharedWebContext.sharedIncognitoContext : context
+        let _context = context
         popupController.createPopupViewForUrl(overlayViewsParent,request.requestedUrl,true,_context)
       }
       else

--- a/WebContainer/SapotContainer/MOD/WebappSettingsPage.qml
+++ b/WebContainer/SapotContainer/MOD/WebappSettingsPage.qml
@@ -201,8 +201,8 @@ FocusScope {
                     objectName: "incognitoOverlay"
 
                     ListItemLayout {
-                        title.text: i18n.tr("Incognito Overlay")
-                        subtitle.text: i18n.tr("Overlay will be in incognito mode")
+                        title.text: i18n.tr("Incognito Overlay (External links)")
+                        subtitle.text: i18n.tr("External links opened in the overlay will be in incognito mode")
                         CheckBox {
                             id: incognitoOverlay
                             SlotsLayout.position: SlotsLayout.Trailing
@@ -429,7 +429,7 @@ FocusScope {
                     visible: settingsObject.appWideScrollPositioner
 
                     height: units.gu(7)
-                    text: i18n.tr("Scroll positioner position")
+                    text: i18n.tr("Position")
                     model: [
                         i18n.tr("Right")
                         ,i18n.tr("Left")
@@ -445,6 +445,39 @@ FocusScope {
                         target: scrollPositionerPosition
                         property: "settingIndex"
                         value: settingsObject.scrollPositionerPosition
+                    }
+                }
+
+                Sapot.ComboBoxItem {
+                    id: scrollPositionerPositionWide
+
+                    property int settingIndex: -1
+
+                    anchors {
+                        left: parent.left
+                        leftMargin: units.gu(3)
+                        right: parent.right
+                        rightMargin: units.gu(2)
+                    }
+                    visible: settingsObject.appWideScrollPositioner
+
+                    height: units.gu(7)
+                    text: i18n.tr("Position (wide layout)")
+                    model: [
+                        i18n.tr("Right")
+                        ,i18n.tr("Left")
+                        ,i18n.tr("Middle")
+                    ]
+                    currentIndex: settingIndex
+
+                    onCurrentIndexChanged: {
+                        settingsObject.scrollPositionerPositionWide = currentIndex
+                    }
+
+                    Binding {
+                        target: scrollPositionerPositionWide
+                        property: "settingIndex"
+                        value: settingsObject.scrollPositionerPositionWide
                     }
                 }
 

--- a/WebContainer/SapotContainer/MOD/WebappWebview.qml
+++ b/WebContainer/SapotContainer/MOD/WebappWebview.qml
@@ -33,7 +33,6 @@ Sapot.WebViewImpl {
     property Sapot.ChromeBase chrome
     property alias scrollTracker: scrollTrackerItem
     property Item scrollPositionerParent: webappWebview
-    property bool wide: false
     property bool webviewPulledDown: false
     readonly property real contentHeight: contentsSize.height / scaleFactor
 
@@ -293,7 +292,7 @@ Sapot.WebViewImpl {
         z: webappWebview.z + 1
         sideMargin: units.gu(2)
         bottomMargin: units.gu(5)
-        position: webapp.settings.scrollPositionerPosition
+        position: webappWebview.wide ? webapp.settings.scrollPositionerPositionWide : webapp.settings.scrollPositionerPosition
         buttonWidthGU: webapp.settings.scrollPositionerSize
         mode: scrollTrackerItem.scrollingUp ? "Up" : "Down"
         forceHide: webappWebview.isFullScreen
@@ -318,4 +317,13 @@ Sapot.WebViewImpl {
         forceHide: webappWebview.isFullScreen
     }
 
+    // Pull up webview when onscreen keyboard is displayed
+    Connections {
+        target: webapp.osk
+        onVisibleChanged: {
+            if (visible) {
+                webappWebview.pullUpWebview()
+            }
+        }
+    }
 }

--- a/WebContainer/SapotContainer/MOD/sapot/ChromeBase.qml
+++ b/WebContainer/SapotContainer/MOD/sapot/ChromeBase.qml
@@ -57,7 +57,7 @@ StyledItem {
         }
     ]
 
-    state: "shown"
+    state: alwaysHidden ? "hidden" : "shown"
 
     y: (state == "shown") ? 0 : yWhenHidden
     Behavior on y {

--- a/WebContainer/SapotContainer/MOD/sapot/GlobalTooltip.qml
+++ b/WebContainer/SapotContainer/MOD/sapot/GlobalTooltip.qml
@@ -29,8 +29,30 @@ QQC2.ToolTip {
 
         let timeoutToUse = customTimeout ? customTimeout : timeout
 
+        hideTimer.startTimer(timeoutToUse)
         show(customText, timeoutToUse)
     }
 
     timeout: 3000
+
+    // WORKAROUND: Sometimes tooltip won't hide anymore
+    // We use this to hide it after the same timeout
+    onYChanged: hideTimer.stop()
+    onTextChanged: hideTimer.stop()
+    onVisibleChanged: {
+        if (!visible) {
+            hideTimer.stop()
+        }
+    }
+    Timer {
+        id: hideTimer
+
+        function startTimer(_timeout) {
+            // Add a bit more delay just because?
+            interval = _timeout + 100
+            restart()
+        }
+
+        onTriggered: tooltip.hide()
+    }
 }

--- a/WebContainer/SapotContainer/MOD/sapot/WebViewImpl.qml
+++ b/WebContainer/SapotContainer/MOD/sapot/WebViewImpl.qml
@@ -327,8 +327,6 @@ WebView {
         {
             contextMenuObj = contextMenuComponent.createObject(webview)
 
-            // Not sure why binding doesn't work properly so we set it here
-            contextMenuObj.showAsCenteredModal = !webview.wide
             if (webview.wide) {
                 contextMenuObj.popup(request.x + units.gu(2), request.y)
             } else {
@@ -354,8 +352,6 @@ WebView {
             } else {
                 contextMenuObj = generalContextMenuComponent.createObject(webview)
 
-                // Not sure why binding doesn't work properly so we set it here
-                contextMenuObj.showAsCenteredModal = !webview.wide
                 if (webview.wide) {
                     contextMenuObj.popup(request.x + units.gu(2), request.y)
                 } else {
@@ -469,6 +465,13 @@ WebView {
                 text: isWebApp ? i18n.tr("Open link in overlay") : i18n.tr("Open link in new window")
                 enabled: !incognito && contextMenu.linkUrl
                 onTriggered: webview.triggerWebAction(WebEngineView.OpenLinkInNewWindow)
+            }
+            CustomizedMenuItem {
+                id: openIncgonitoOverlayMenuItem
+                objectName: "openIncgonitoOverlayMenuItem"
+                text: isWebApp ? i18n.tr("Open link in incognito overlay") : i18n.tr("Open link in incognito window")
+                enabled: !incognito && contextMenu.linkUrl
+                onTriggered: webview.openOverlayForUrl(contextMenu.linkUrl, true)
             }
             CustomizedMenuItem {
                 id: openExternallyMenuItem

--- a/WebContainer/SapotContainer/MOD/webapp-container.qml
+++ b/WebContainer/SapotContainer/MOD/webapp-container.qml
@@ -314,6 +314,12 @@ Sapot.BrowserWindow {
         property int floatingScrollButtonSize: 6 // In Grid Units
         property bool enableFloatingScrollButtonAsPositioner: false
         property int floatingScrollButtonVerticalMargin: 2 // In Grid Units
+        property int scrollPositionerPositionWide: Sapot.ScrollPositionerItem.Position.Right
+        /*
+         * ScrollPositionerItem.Position.Right
+         * ScrollPositionerItem.Position.Left
+         * ScrollPositionerItem.Position.Middle
+        */
 
 
         Component.onCompleted: Sapot.Haptics.enabled = Qt.binding( function() { return enableHaptics } )
@@ -327,6 +333,7 @@ Sapot.BrowserWindow {
             enableHaptics = true;
             appWideScrollPositioner = false;
             scrollPositionerPosition = Sapot.ScrollPositionerItem.Position.Right;
+            scrollPositionerPositionWide = Sapot.ScrollPositionerItem.Position.Right;
             scrollPositionerSize = 8;
             enableWebviewPullDownGestures = false;
             physicalForGestures = false;


### PR DESCRIPTION
- Pull up webview when onscreen keyboard is displayed
- Option to put the scroll positioner to a different position when in wide layout
- Changed the behavior of the Incognito overlay setting. It will now only affect external links when opened on an overlay.
  For internal links, a new option to explicitly open them in invognito overlay has been added
- Title bar now hides immediately upon start up when the webapp is set to always hide it
- Implemented work around to hide tooltip when it gets stuck being shown
- Fixed context menu position when opened with mouse in wide layout

Updated Block OTA for compatibility with recent OTAs